### PR TITLE
Display only changed items in updating monitors

### DIFF
--- a/barkdog.gemspec
+++ b/barkdog.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'dogapi'
   spec.add_dependency 'term-ansicolor'
+  spec.add_dependency 'diffy'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/barkdog.rb
+++ b/lib/barkdog.rb
@@ -2,6 +2,7 @@ require 'dogapi'
 require 'logger'
 require 'singleton'
 require 'term/ansicolor'
+require 'diffy'
 
 module Barkdog; end
 

--- a/lib/barkdog/client.rb
+++ b/lib/barkdog/client.rb
@@ -63,7 +63,7 @@ class Barkdog::Client
     monitor_id = actual_without_id.delete('id')
 
     if expected != actual_without_id
-      updated = @driver.update_monitor(name, expected.merge('id' => monitor_id)) || updated
+      updated = @driver.update_monitor(name, expected.merge('id' => monitor_id), actual) || updated
     end
 
     updated

--- a/lib/barkdog/dsl/converter.rb
+++ b/lib/barkdog/dsl/converter.rb
@@ -51,17 +51,16 @@ end
   def output_monitor_options(monitor_options)
     options_body = monitor_options.map {|key, value|
       value_is_hash = value.is_a?(Hash)
-      value = value.inspect
 
       if value_is_hash
-        value = unbrace(value).strip
+        value = value.map{ |k,v| "#{k.inspect}=>#{v.inspect}" }.sort.join(", ")
         value = value.empty? ? '({})' : " #{value}"
       else
-        value = " #{value}"
+        value = " #{value.inspect}"
       end
 
       "#{key}#{value}"
-    }.join("\n    ")
+    }.sort.join("\n    ")
 
     <<-RUBY.chomp
   options do

--- a/spec/barkdog_spec.rb
+++ b/spec/barkdog_spec.rb
@@ -7,9 +7,9 @@ monitor "my metric check", :type=>"metric alert" do
   query "avg(last_5m):avg:datadog.dogstatsd.packet.count{*} > 1"
   message "metric check message"
   options do
-    notify_no_data false
     no_data_timeframe 2
     notify_audit false
+    notify_no_data false
     silenced({})
   end
 end
@@ -18,14 +18,14 @@ monitor "my service check", :type=>"service check" do
   query "\"datadog.agent.up\".over(\"*\").last(2).count_by_status()"
   message "service check message"
   options do
-    notify_audit false
-    timeout_h 0
-    silenced({})
-    thresholds "warning"=>1, "ok"=>1, "critical"=>1
-    period 15
-    notify_no_data true
-    renotify_interval 0
     no_data_timeframe 2
+    notify_audit false
+    notify_no_data true
+    period 15
+    renotify_interval 0
+    silenced({})
+    thresholds "critical"=>1, "ok"=>1, "warning"=>1
+    timeout_h 0
   end
 end
     RUBY
@@ -50,9 +50,9 @@ monitor "my metric check", :type=>"metric alert" do
   query "avg(last_5m):avg:datadog.dogstatsd.packet.count{*} > 2"
   message "metric check message2"
   options do
-    notify_no_data true
     no_data_timeframe 3
     notify_audit true
+    notify_no_data true
     silenced "*"=>nil
   end
 end
@@ -61,14 +61,14 @@ monitor "my service check", :type=>"service check" do
   query "\"datadog.agent.up\".over(\"*\").last(3).count_by_status()"
   message "service check message2"
   options do
-    notify_audit true
-    timeout_h 1
-    silenced "*"=>nil
-    thresholds "warning"=>2, "ok"=>2, "critical"=>2
-    period 30
-    notify_no_data true
-    renotify_interval 1
     no_data_timeframe 3
+    notify_audit true
+    notify_no_data true
+    period 30
+    renotify_interval 1
+    silenced "*"=>nil
+    thresholds "critical"=>2, "ok"=>2, "warning"=>2
+    timeout_h 1
   end
 end
       RUBY


### PR DESCRIPTION
Hi,

![barkdog](https://cloud.githubusercontent.com/assets/290039/8642883/93f21b74-2966-11e5-9593-db22dc471fb6.png)

I modified `Barkdog.Driver.update_monitor` for displaying output like above. I think this is useful for knowing what parts will be changed in applying. How do you think about this change?
