### PR TITLE
Add a --no-delete option to prevent deletion of missing monitors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage: barkdog [options]
     -e, --export
     -o, --output FILE
         --no-color
+        --no-delete
         --debug
     -h, --help
 ```

--- a/bin/barkdog
+++ b/bin/barkdog
@@ -22,6 +22,7 @@ options = {
   :dry_run         => false,
   :ignore_silenced => false,
   :color           => true,
+  :delete          => true,
   :debug           => false,
 }
 
@@ -36,6 +37,7 @@ ARGV.options do |opt|
     opt.on('-e', '--export')          {    mode                       = :export  }
     opt.on('-o', '--output FILE')     {|v| output_file                = v        }
     opt.on(''  , '--no-color')        {    options[:color]            = false    }
+    opt.on(''  , '--no-delete')       {    options[:delete]           = false    }
     opt.on(''  , '--debug')           {    options[:debug]            = true     }
 
     opt.on('-h', '--help') do

--- a/lib/barkdog/driver.rb
+++ b/lib/barkdog/driver.rb
@@ -31,6 +31,8 @@ class Barkdog::Driver
   end
 
   def delete_monitor(name, attrs)
+    return false unless @options[:delete]
+
     updated = false
     log(:info, "Delete Monitor: #{name}", :color => :red)
 


### PR DESCRIPTION
Default behavior remains unchanged.

Use case for this is when migrating from manually created monitors to ones managed by Barkdog, rather than doing them all at once, we wanted to be able to move a few to the automation without deleting all our old ones. We were able to use this option during the transition, and then eventually stop using it once all monitors were defined in our Barkfile.
