### PR TITLE
Disable the 'silent' setting for Dogapi.

### DIFF
--- a/lib/barkdog/client.rb
+++ b/lib/barkdog/client.rb
@@ -8,7 +8,9 @@ class Barkdog::Client
     raise 'API Key does not exist' unless api_key
     raise 'Application Key does not exist' unless app_key
 
-    @dog = Dogapi::Client.new(api_key, app_key)
+    # api_key, application_key=nil, host=nil, device=nil, silent=true, timeout=nil
+    # We force silent to false so any exceptions get propated back out and we fail loudly.
+    @dog = Dogapi::Client.new(api_key, app_key, nil, nil, false)
     @driver = Barkdog::Driver.new(@dog, @options)
   end
 


### PR DESCRIPTION
If the dogapi encounters a network issue (say Net::ReadTimeout), barkdog will continue processing because no exception was raised from dogapi client. This can cause situations where duplicate monitors are created in DD, and the next run of barkdog will fail due to duplicates existing.

Making dogapi fail loudly forces barkdog to not continue in the event the current list of monitors can't be gathered for any reason.
