### PR TITLE
Add nil check when ignoring silenced option.

### DIFF
--- a/lib/barkdog/driver.rb
+++ b/lib/barkdog/driver.rb
@@ -47,8 +47,8 @@ class Barkdog::Driver
     updated = false
 
     if @options[:ignore_silenced]
-      expected['options'].delete('silenced')
-      actual['options'].delete('silenced')
+      expected['options'].delete('silenced') if expected['options']
+      actual['options'].delete('silenced') if actual['options']
     end
 
     diffy = Diffy::Diff.new(


### PR DESCRIPTION
It's possible to hit a condition where this fails when using the `--ignore-silenced` option. Adding the nil check prevents that happening.
