### PR TITLE
Add option to set the timeout that dogapi uses. Keep defaults same as today.

### DIFF
--- a/bin/barkdog
+++ b/bin/barkdog
@@ -24,21 +24,23 @@ options = {
   :color           => true,
   :delete          => true,
   :debug           => false,
+  :datadog_timeout => nil
 }
 
 ARGV.options do |opt|
   begin
-    opt.on(''  , '--api-key API_KEY') {|v| options[:api_key]          = v       }
-    opt.on(''  , '--app-key APP_KEY') {|v| options[:application_key]  = v       }
-    opt.on('-a', '--apply')           {    mode                       = :apply   }
-    opt.on('-f', '--file FILE')       {|v| file                       = v        }
-    opt.on(''  , '--dry-run')         {    options[:dry_run]          = true     }
-    opt.on(''  , '--ignore-silenced') {    options[:ignore_silenced]  = true     }
-    opt.on('-e', '--export')          {    mode                       = :export  }
-    opt.on('-o', '--output FILE')     {|v| output_file                = v        }
-    opt.on(''  , '--no-color')        {    options[:color]            = false    }
-    opt.on(''  , '--no-delete')       {    options[:delete]           = false    }
-    opt.on(''  , '--debug')           {    options[:debug]            = true     }
+    opt.on(''  , '--api-key API_KEY')         {|v| options[:api_key]          = v        }
+    opt.on(''  , '--app-key APP_KEY')         {|v| options[:application_key]  = v        }
+    opt.on('-a', '--apply')                   {    mode                       = :apply   }
+    opt.on('-f', '--file FILE')               {|v| file                       = v        }
+    opt.on(''  , '--dry-run')                 {    options[:dry_run]          = true     }
+    opt.on(''  , '--ignore-silenced')         {    options[:ignore_silenced]  = true     }
+    opt.on('-e', '--export')                  {    mode                       = :export  }
+    opt.on('-o', '--output FILE')             {|v| output_file                = v        }
+    opt.on(''  , '--no-color')                {    options[:color]            = false    }
+    opt.on(''  , '--no-delete')               {    options[:delete]           = false    }
+    opt.on(''  , '--debug')                   {    options[:debug]            = true     }
+    opt.on(''  , '--datadog-timeout TIMEOUT') {|v| options[:datadog_timeout]  = v.to_i   }
 
     opt.on('-h', '--help') do
       puts opt.help

--- a/lib/barkdog/client.rb
+++ b/lib/barkdog/client.rb
@@ -10,7 +10,7 @@ class Barkdog::Client
 
     # api_key, application_key=nil, host=nil, device=nil, silent=true, timeout=nil
     # We force silent to false so any exceptions get propated back out and we fail loudly.
-    @dog = Dogapi::Client.new(api_key, app_key, nil, nil, false)
+    @dog = Dogapi::Client.new(api_key, app_key, nil, nil, false, @options[:datadog_timeout])
     @driver = Barkdog::Driver.new(@dog, @options)
   end
 


### PR DESCRIPTION
If you have a _lot_ of monitors, the default 5s timeout can easily be hit. Add ability for users to set this themselves.
