### PR TITLE
Add ability to not continue when datadog reports no existing monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Usage: barkdog [options]
         --no-delete
         --debug
         --datadog-timeout TIMEOUT
+        --fail-if-empty
     -h, --help
 ```
 

--- a/bin/barkdog
+++ b/bin/barkdog
@@ -23,7 +23,8 @@ options = {
   :ignore_silenced => false,
   :color           => true,
   :debug           => false,
-  :datadog_timeout => nil
+  :datadog_timeout => nil,
+  :fail_if_empty   => false
 }
 
 ARGV.options do |opt|
@@ -40,6 +41,7 @@ ARGV.options do |opt|
     opt.on(''  , '--no-delete')               {    options[:no_delete]        = true     }
     opt.on(''  , '--debug')                   {    options[:debug]            = true     }
     opt.on(''  , '--datadog-timeout TIMEOUT') {|v| options[:datadog_timeout]  = v.to_i   }
+    opt.on(''  , '--fail-if-empty')           {    options[:fail_if_empty]    = false    }
 
     opt.on('-h', '--help') do
       puts opt.help

--- a/lib/barkdog/client.rb
+++ b/lib/barkdog/client.rb
@@ -28,6 +28,9 @@ class Barkdog::Client
   def walk(file)
     expected = load_file(file)
     actual = Barkdog::Exporter.export(@dog, @options)
+    if actual.empty? && @options[:fail_if_empty]
+      raise 'Zero existing monitors reported, failing as --fail-if-empty is set'
+    end
     walk_monitors(expected, actual)
   end
 


### PR DESCRIPTION
We're having an ongoing issue where for some reason DataDog returns no monitors to barkdog, resulting in a duplication of all of our monitors. This flag / check will allow us to not duplicate all our monitors in these cases. 