### PR TITLE
Add the ability to tag monitors in Datadog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Usage: barkdog [options]
     -o, --output FILE
         --no-color
         --no-delete
+        --delete-only-tagged TAG
         --debug
         --datadog-timeout TIMEOUT
     -h, --help

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Usage: barkdog [options]
 monitor "Check load avg", :type=>"metric alert" do
   query "avg(last_5m):avg:ddstat.load_avg.1m{host:i-XXXXXXXX} > 1"
   message "@winebarrel@example.net"
+  tags ["load", "host", "example"]
   options do
     locked false
     new_host_delay 300

--- a/bin/barkdog
+++ b/bin/barkdog
@@ -38,6 +38,7 @@ ARGV.options do |opt|
     opt.on('-o', '--output FILE')             {|v| output_file                = v        }
     opt.on(''  , '--no-color')                {    options[:color]            = false    }
     opt.on(''  , '--no-delete')               {    options[:no_delete]        = true     }
+    opt.on(''  , '--delete-only-tagged TAG')  {|v| options[:delete_tagged]    = v        }
     opt.on(''  , '--debug')                   {    options[:debug]            = true     }
     opt.on(''  , '--datadog-timeout TIMEOUT') {|v| options[:datadog_timeout]  = v.to_i   }
 

--- a/lib/barkdog/driver.rb
+++ b/lib/barkdog/driver.rb
@@ -36,6 +36,11 @@ class Barkdog::Driver
   def delete_monitor(name, attrs)
     return false if @options[:no_delete]
 
+    # If restricting deletions to a tag, validate the tag
+    if @options[:delete_tagged]
+      return false unless attrs['tags'].include?(@options[:delete_tagged])
+    end
+
     updated = false
     log(:info, "Delete Monitor: #{name}", :color => :red)
 

--- a/lib/barkdog/driver.rb
+++ b/lib/barkdog/driver.rb
@@ -14,13 +14,16 @@ class Barkdog::Driver
       attrs['options'].delete('silenced')
     end
 
+    tags = attrs['tags'] || []
+
     unless @options[:dry_run]
       _, response = @dog.monitor(
         attrs['type'],
         attrs['query'],
         :name => name,
         :message => attrs['message'],
-        :options => attrs['options']
+        :options => attrs['options'],
+        :tags => tags
       )
 
       validate_response(response)
@@ -69,7 +72,8 @@ class Barkdog::Driver
           expected['query'],
           :name => name,
           :message => expected['message'],
-          :options => expected['options']
+          :options => expected['options'],
+          :tags => expected['tags']
         )
 
         validate_response(response)

--- a/lib/barkdog/dsl/context/monitor.rb
+++ b/lib/barkdog/dsl/context/monitor.rb
@@ -20,6 +20,10 @@ class Barkdog::DSL::Context::Monitor
     @result['message'] = value.to_s
   end
 
+  def tags(value)
+    @result['tags'] = value.to_a
+  end
+
   def options(&block)
     @result['options'] = Barkdog::DSL::Context::Monitor::Options.new(@context, &block).result
   end

--- a/lib/barkdog/dsl/converter.rb
+++ b/lib/barkdog/dsl/converter.rb
@@ -25,6 +25,7 @@ class Barkdog::DSL::Converter
     fixed_options = Hash[Barkdog::FIXED_OPTION_KEYS.map {|k| [k.to_sym, attrs[k]] }]
     query = attrs['query']
     message = attrs['message']
+    tags = attrs['tags'] || []
     monitor_options = attrs['options'] || {}
 
     if monitor_options.empty?
@@ -33,10 +34,17 @@ class Barkdog::DSL::Converter
       monitor_options = "\n" + output_monitor_options(monitor_options)
     end
 
+    if tags.empty?
+      tags_output = ''
+    else
+      tags_output = "\n  tags #{tags.inspect}"
+    end
+
     <<-EOS
 monitor #{monitor_name.inspect}, #{unbrace(fixed_options.inspect)} do
   query #{query.inspect}
   message #{message.inspect}#{
+  tags_output}#{
   monitor_options}
 end
     EOS


### PR DESCRIPTION
This adds a new "tags" attribute, which allows us to specify an array of tags that can be added to monitors. These can be used to then filter monitors when searching in the Datadog UI, which makes tracking down certain classes of monitor easier.

If monitors don't have any tags set, then that attribute is skipped when exporting, so there should be no change for current users who don't want to use tags with barkdog.

This also adds a new option `--delete-only-tagged TAG`, where barkdog will only delete monitors if they have that specific tag set. The intent is to allow us to add a tag to all our barkdog managed monitors, e.g. `auto-managed`. This way we can turn on deletions for our barkdog managed monitors, without wiping out any "lovingly hand-crafted monitors".

Example usage would be `--delete-only-tagged "auto-managed"`, and this would essentially mean barkdog only manages monitors with that tag going forward, without deleting any others.